### PR TITLE
Add RSpec test reporter to CI workflows

### DIFF
--- a/.github/workflows/test-nonparallel.yml
+++ b/.github/workflows/test-nonparallel.yml
@@ -65,6 +65,7 @@ jobs:
           name: RSpec Tests
           path: '${{ inputs.base_path }}/tmp/rspec-results*.json'
           reporter: rspec-json
+          list-tests: failed
           fail-on-error: false
 
       - name: Build and upload application documentation

--- a/.github/workflows/test-nonparallel.yml
+++ b/.github/workflows/test-nonparallel.yml
@@ -65,6 +65,7 @@ jobs:
           name: RSpec Tests
           path: '${{ inputs.base_path }}/tmp/rspec-results*.xml'
           reporter: java-junit
+          list-tests: all
           fail-on-error: false
 
       - name: Build and upload application documentation

--- a/.github/workflows/test-nonparallel.yml
+++ b/.github/workflows/test-nonparallel.yml
@@ -63,9 +63,8 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: RSpec Tests
-          path: '${{ inputs.base_path }}/tmp/rspec-results*.xml'
-          reporter: java-junit
-          list-tests: all
+          path: '${{ inputs.base_path }}/tmp/rspec-results*.json'
+          reporter: rspec-json
           fail-on-error: false
 
       - name: Build and upload application documentation

--- a/.github/workflows/test-nonparallel.yml
+++ b/.github/workflows/test-nonparallel.yml
@@ -36,9 +36,6 @@ jobs:
     name: Application
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    permissions:
-      checks: write
-      pull-requests: write
     steps:
       - name: Prepare the environment
         uses: hausgold/actions/ci@v2

--- a/.github/workflows/test-nonparallel.yml
+++ b/.github/workflows/test-nonparallel.yml
@@ -36,6 +36,9 @@ jobs:
     name: Application
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
       - name: Prepare the environment
         uses: hausgold/actions/ci@v2
@@ -57,6 +60,15 @@ jobs:
       - name: Upload the code coverage report
         run: coverage
         working-directory: '${{ inputs.base_path }}'
+
+      - name: Publish RSpec test report
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: RSpec Tests
+          path: '${{ inputs.base_path }}/tmp/rspec-results*.xml'
+          reporter: java-junit
+          fail-on-error: false
 
       - name: Build and upload application documentation
         run: api-docs --skip-upload && coverage --docs-only

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -132,6 +132,8 @@ jobs:
         working-directory: '${{ inputs.base_path }}'
 
       - name: Download RSpec test results
+        if: always()
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: rspec-junit-*
@@ -139,6 +141,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish RSpec test report
+        if: always()
         uses: dorny/test-reporter@v1
         with:
           name: RSpec Tests

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -146,4 +146,5 @@ jobs:
           name: RSpec Tests
           path: rspec-json/**/*.json
           reporter: rspec-json
+          list-tests: failed
           fail-on-error: false

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -72,6 +72,10 @@ jobs:
         run: coverage part
         working-directory: '${{ inputs.base_path }}'
 
+      - name: List RSpec output files (debug)
+        if: always()
+        run: find '${{ inputs.base_path }}/tmp' -name 'rspec-results*' 2>/dev/null || echo 'No rspec-results files found'
+
       - name: Upload RSpec test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -76,8 +76,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: rspec-junit-${{ strategy.job-index }}
-          path: '${{ inputs.base_path }}/tmp/rspec-results*.xml'
+          name: rspec-json-${{ strategy.job-index }}
+          path: '${{ inputs.base_path }}/tmp/rspec-results*.json'
           if-no-files-found: ignore
 
   targets:
@@ -136,8 +136,8 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          pattern: rspec-junit-*
-          path: rspec-junit/
+          pattern: rspec-json-*
+          path: rspec-json/
           merge-multiple: true
 
       - name: Publish RSpec test report
@@ -145,7 +145,6 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: RSpec Tests
-          path: rspec-junit/**/*.xml
-          reporter: java-junit
-          list-tests: all
+          path: rspec-json/**/*.json
+          reporter: rspec-json
           fail-on-error: false

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -72,6 +72,14 @@ jobs:
         run: coverage part
         working-directory: '${{ inputs.base_path }}'
 
+      - name: Upload RSpec test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rspec-junit-${{ strategy.job-index }}
+          path: '${{ inputs.base_path }}/tmp/rspec-results*.xml'
+          if-no-files-found: ignore
+
   targets:
     name: Targets
     runs-on: ubuntu-24.04
@@ -109,6 +117,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [specs, targets]
+    if: always()
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
       - name: Prepare the environment
         uses: hausgold/actions/ci@v2
@@ -121,3 +133,18 @@ jobs:
       - name: Upload the code coverage report
         run: coverage merge
         working-directory: '${{ inputs.base_path }}'
+
+      - name: Download RSpec test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rspec-junit-*
+          path: rspec-junit/
+          merge-multiple: true
+
+      - name: Publish RSpec test report
+        uses: dorny/test-reporter@v1
+        with:
+          name: RSpec Tests
+          path: rspec-junit/**/*.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -118,9 +118,6 @@ jobs:
     timeout-minutes: 5
     needs: [specs, targets]
     if: always()
-    permissions:
-      checks: write
-      pull-requests: write
     steps:
       - name: Prepare the environment
         uses: hausgold/actions/ci@v2

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -147,4 +147,5 @@ jobs:
           name: RSpec Tests
           path: rspec-junit/**/*.xml
           reporter: java-junit
+          list-tests: all
           fail-on-error: false

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -138,7 +138,6 @@ jobs:
         with:
           pattern: rspec-json-*
           path: rspec-json/
-          merge-multiple: true
 
       - name: Publish RSpec test report
         if: always()


### PR DESCRIPTION
Adds RSpec test result reporting to both parallel and non-parallel test workflows using `dorny/test-reporter`. After all spec jobs complete, the results are published as a GitHub Check Run called **RSpec Tests** on the PR or commit — failures are listed individually with expandable error output. No more scrolling through logs.

The reporter uses RSpec's built-in JSON formatter (`rspec-json`), so services do not need the `rspec_junit_formatter` gem.

For the **non-parallel** workflow, a `--format json --out` line in `.rspec` is enough — the file is written once and picked up by the publish step at the end of the job.

For the **parallel** workflow, the formatter must be registered in `spec_helper.rb` rather than `.rspec`, because `parallel_tests`' rake task invocation does not pass `.rspec` formatter config through to workers. `spec_helper.rb` is explicitly required by each worker subprocess. `TEST_ENV_NUMBER` (already used for SimpleCov) gives each worker a unique output filename so they don't overwrite each other.

Each `specs` matrix job uploads its JSON files as an artifact named `rspec-json-N`. The `finalize` job downloads all artifacts into subdirectories and publishes the consolidated report. `finalize` runs with `if: always()` so the report appears even when tests fail. The report steps use `fail-on-error: false` and `continue-on-error: true` so a missing JSON file does not break the build.

`dorny/test-reporter` also supports `jest-junit` and `mocha-json`, so the same approach can be applied to frontend services using Jest or Mocha — no additional tooling needed.

> [!NOTE]
> Services need to opt in. For single-worker services: add `--format json --out tmp/rspec-results.json` to `.rspec`. For parallel services: register the formatter in `spec_helper.rb` using `TEST_ENV_NUMBER`. Without any output file the upload and report steps silently no-op.

> [!WARNING]
> **Todo** — Verify this works correctly for repos that do not use RSpec at all. A real CI run against a non-RSpec service (e.g. a pure frontend) is needed to confirm nothing silently breaks.

## Example PRs with enabled test reporter
- hausgold/payment-api#216 — `test-nonparallel`
- hausgold/maklerportal-api#1636 — `test-parallel`